### PR TITLE
RGFW / present_frame optimizations.

### DIFF
--- a/main.c
+++ b/main.c
@@ -126,7 +126,8 @@ int main(void)
         scenario_render(&world);
 
         const u32 *fb = render_get_fb();
-        present_frame(fb);
+
+        thpool_add_work(render_threadpool, present_frame, (void*)fb);
 
         print_fps(now);
     }

--- a/src/window.h
+++ b/src/window.h
@@ -40,7 +40,7 @@ static int window_init(const char *title, int w, int h)
     
     /* Create reusable surface for presentation (avoids per-frame XImage allocation) */
     g_surface = RGFW_window_createSurface(g_window, NULL, w, h, RGFW_formatBGRA8);
-    
+
     return 0;
 }
 
@@ -60,28 +60,21 @@ static int is_running(void)
  * Note: For X11, we reuse the surface (g_surface) created at init time.
  * The surface's data pointer is updated each frame, avoiding XImage allocation.
  */
-static void present_frame(const u32 *fb)
+static void present_frame(void *fb)
 {
-    if (!g_window || !fb) return;
-    
-    extern i32 fw, fh;
-    int w = fw;
-    int h = fh;
-    
-    /* Ensure surface exists (may have been freed during resize) */
-    if (!g_surface) {
-        g_surface = RGFW_window_createSurface(g_window, NULL, w, h, RGFW_formatBGRA8);
-    }
-    
-    if (g_surface) {
-        /* Update surface data pointer to current framebuffer without reallocating */
-        /* Format is 0x00BBGGRR (BGRA with 0 alpha), which matches RGFW_formatBGRA8 layout */
-        g_surface->data = (u8*)fb;
-        /* Width/height may change on resize */
-        g_surface->w = w;
-        g_surface->h = h;
-        RGFW_window_blitSurface(g_window, g_surface);
-    }
+    if (!g_window || !fb || !g_surface || !g_surface->native.bitmap) return;
+
+    /* Update the XImage's data pointer to our framebuffer.
+     * XCreateImage allocates the XImage struct but not the data buffer.
+     * We point it directly at our fb to avoid memcpy. */
+    g_surface->native.bitmap->data = (char*)fb;
+
+    XPutImage(_RGFW->display,
+        g_window->src.window, g_window->src.gc, g_surface->native.bitmap,
+        0, 0, 0, 0, (u32)g_surface->w, (u32)g_surface->h);
+
+    /* Clear data pointer so XDestroyImage (called on resize/shutdown) won't free our fb */
+    g_surface->native.bitmap->data = NULL;
 }
 
 /* Cleanup window resources */
@@ -103,13 +96,13 @@ static void window_resize(int new_w, int new_h)
 {
     /* Recreate surface with new dimensions since XImage has fixed size */
     RGFW_surface *old_surface = g_surface;
-    
+
     render_resize(new_w, new_h);
-    
+
     if (old_surface) {
         RGFW_surface_free(old_surface);
     }
-    
+
     /* Recreate surface with new dimensions */
     g_surface = RGFW_window_createSurface(g_window, NULL, new_w, new_h, RGFW_formatBGRA8);
     if (!g_surface) {


### PR DESCRIPTION
RGFW_window_blitSurface() was performing an unnecessary malloc & memcpy over the entire framebuffer each frame. We can avoid this by instead only using RGFW to create the window, and then manually calling XPutImage() using a pointer to our renderer's front buffer. This alone is a huge increase in performance.

Additionally instead of calling `present_frame()` directly we can throw it into our threadpool without an accompanying wait. This seems insidious but it only interacts with a pointer which is double-buffered. Our scenario_render call stack calls wait a few times before the buffers are swapped, so this appears to actually be safe, and also provides a huge performance increase. Interestingly this makes our threadpool have lower CPU utilization (which is a bad thing) - this is because only one `present_frame()` is usually present in the threadpool, and I suspect we are calling `wait` at a point where all other threads have to wait for it to finish. We want to aim to maximize CPU utilization in our thread pool, so theoretically if we can defer some `waits` or squeeze more threadpool jobs in between `present_frame` and the waits, we can bring our utilization up which means better even better performance.

Overall these two changes have increased framerate in the demo scene by nearly 20% (I went from about 220-240fps up to 260-280fps.)